### PR TITLE
Fix: Refresh guest list after RSVP submission

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -352,6 +352,8 @@ export default function WeddingRSVPWebsite() {
       }
 
       alert('Thank you for your RSVP! We can\'t wait to celebrate with you! 💕');
+      const updatedList = await fetchGuestList();
+      setGuestList(updatedList as { name: string; guests: number }[]);
       // Reset form state on successful submission
       setFormData({
         name: '',


### PR DESCRIPTION
This commit addresses an issue where guests who had already RSVP'd were still appearing in the name suggestions on the RSVP form.

The `handleSubmit` function in `src/app/page.tsx` has been modified to re-fetch and update the guest list after a successful RSVP submission. This ensures that the suggestions are always based on the most up-to-date list of guests who have not yet responded, preventing already responded guests from appearing.